### PR TITLE
Adds DO firewall support

### DIFF
--- a/index_cluster/main.tf
+++ b/index_cluster/main.tf
@@ -56,13 +56,16 @@ resource "digitalocean_firewall" "icm" {
   inbound_rule {
     protocol = "tcp"
     port_range = "22"
+    # Set to be accessible from your current external IP only - switch if this is expected to change
     source_addresses = ["${chomp(data.http.client_ip.body)}/32"]
     # source_addresses = ["0.0.0.0/0", "::/0"]
   }
   inbound_rule {
     protocol = "tcp"
     port_range = "8000"
+    # Set to be accessible from your current external IP only - switch if this is expected to change
     source_addresses = ["${chomp(data.http.client_ip.body)}/32"]
+    # source_addresses = ["0.0.0.0/0", "::/0"]
   }
   inbound_rule {
     protocol = "tcp"
@@ -110,7 +113,9 @@ resource "digitalocean_firewall" "idx" {
   inbound_rule {
     protocol = "tcp"
     port_range = "22"
+    # Set to be accessible from your current external IP only - switch if this is expected to change
     source_addresses = ["${chomp(data.http.client_ip.body)}/32"]
+    # source_addresses = ["0.0.0.0/0", "::/0"]
   }
   inbound_rule {
     protocol = "tcp"


### PR DESCRIPTION
Limits ports at the DigitalOcean level to those required by Splunk (and SSH). Inter-Splunk connection ports are limited to only be accessible from the spawned instances.

`22` (and `8000` on the ICM) are opened to only be accessible from your public IP at the time of provisioning.
If your IP is likely to change, swap that line out with the commented global port range.

Closes #2.