### PR TITLE
Splunk app deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@
 
 # Ansible
 *.retry
+
+# Temporary Ansible inventory
+icm_host
+
+# Local Splunk app packages
+index_cluster/files/icm/master-apps/*.*

--- a/index_cluster/README.md
+++ b/index_cluster/README.md
@@ -8,3 +8,5 @@ This plan will by default create:
 These instances will be created in the AMS3 DigitalOcean region, and will be 1 vCPU x 1GB droplets.
 
 This and more can be configured by overriding the variables in [vars.tf](./vars.tf) - either as environment variables, or by placing them in `terraform.tfvars`.
+
+You can also deploy Splunk apps automatically to all spawned indexers by placing the archive (`.tar`, `.tgz`, `.tar.gz`, or `.spl`) for the individual apps in `files/icm/master-apps/`.

--- a/index_cluster/main.tf
+++ b/index_cluster/main.tf
@@ -28,7 +28,7 @@ resource "digitalocean_droplet" "icm" {
   ssh_keys = ["${digitalocean_ssh_key.default.fingerprint}"]
   tags = ["${digitalocean_tag.icm.id}"]
   provisioner "local-exec" {
-    command = "sleep 30; ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u root -i '${self.ipv4_address},' -e 'ansible_python_interpreter=/usr/bin/python3' -e 'prefix=${var.prefix}' -e sites_string=$(python sites_string.py icm ${var.num_sites}) -e 'splunk_password=${var.splunk_password}' -e 'splunk_download=${var.splunk_download}' master.yml -t icm"
+    command = "sleep 30; echo '${self.ipv4_address} ansible_python_interpreter=/usr/bin/python3' > icm_host; ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u root -i './icm_host' -e 'prefix=${var.prefix}' -e sites_string=$(python sites_string.py icm ${var.num_sites}) -e 'splunk_password=${var.splunk_password}' -e 'splunk_download=${var.splunk_download}' master.yml -t icm"
   }
 }
 

--- a/index_cluster/master.yml
+++ b/index_cluster/master.yml
@@ -27,6 +27,23 @@
             src: "files/icm/master-apps/_cluster/local/indexes.conf"
             dest: "/opt/splunk/etc/master-apps/_cluster/local/indexes.conf"
             mode: 0644
+
+        - name: "check for local Splunk apps"
+          find:
+            paths: "files/icm/master-apps"
+            patterns: "*.*,*.tar,*.tgz,*.spl"
+            depth: 1
+          delegate_to: localhost
+          register: local_splunk_apps
+
+        - name: "ship local apps to the ICM"
+          unarchive:
+            # src: "files/icm/master-apps/{{ item }}"
+            src: "{{ item.path }}"
+            dest: "/opt/splunk/etc/master-apps/"
+            mode: 0755
+          loop: "{{ local_splunk_apps.files }}"
+          when: local_splunk_apps.matched > 0
       tags: icm
 
     - block:


### PR DESCRIPTION
Adds support for deploying Splunk apps to the indexer cluster via the ICM at provision time.

Closes #16 